### PR TITLE
fix bad handle url

### DIFF
--- a/gen-five/src/python/settings.py
+++ b/gen-five/src/python/settings.py
@@ -100,7 +100,7 @@ CITATION_URLS = { 'CMIP6' : {'test' :
 }
 
 
-PID_URL = 'http://hd1.handle.net/{}|PID|pid'  # PIDs include hdl:
+PID_URL = 'http://hdl.handle.net/{}|PID|pid'  # PIDs include hdl:
 TEST_PUB = False
 
 PROJECT = "CMIP6"  # project setting.  This would be used to consider some project-specific features, eg. for CMIP6


### PR DESCRIPTION
We have published a lot of PID urls with an incorrect handle.  I'll push a frontend fix and encourage other sites, but hopefully this will correct future publishing if not already fixed.  I don't see this in the settings.py in pkg which is good.